### PR TITLE
Revert "updating simple-helm-toolchain for use with headless (#51)"

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -22,9 +22,7 @@ template:
           '[' + $env.branch + ']('+ $env.repository + '/tree/' + $env.branch + ')' :
           '[master]('+ $env.repository + '/tree/master)'
 toolchain:
-  name: >
-    $env.toolchainName ? '{{toolchainName}}' :
-      'helm-toolchain-{{timestamp}}'
+  name: 'helm-toolchain-{{timestamp}}'
   template:
     getting_started:
      $ref: "#/messages/template.gettingStarted"
@@ -33,17 +31,13 @@ services:
     service_id: >
       $env.source_provider ? $env.source_provider : 'hostedgit'
     parameters:
-      repo_name: >
-        $env.toolchainName ? '{{toolchainName}}' :
-          'hello-helm-{{timestamp}}'
+      repo_name: 'hello-helm-{{timestamp}}'
       repo_url: >
-        $env.type === 'link' ? $env.app_repo :
-          $env.sourceZipUrl ? '{{sourceZipUrl}}' :
-            'https://github.com/open-toolchain/hello-helm'
+        $env.type === 'link' ? 
+          $env.app_repo : 'https://github.com/open-toolchain/hello-helm'
       source_repo_url: >
-        $env.type === 'fork' || $env.type === 'clone' ? $env.app_repo :
-          $env.sourceZipUrl ? '{{sourceZipUrl}}' : 
-            'https://github.com/open-toolchain/hello-helm'
+        $env.type === 'fork' || $env.type === 'clone' ? 
+          $env.app_repo : 'https://github.com/open-toolchain/hello-helm'
       type: $env.type || 'clone'
       has_issues: true
       enable_traceability: false
@@ -52,7 +46,7 @@ services:
     parameters:
       services:
         - repo
-      name: '{{services.repo.parameters.repo_name}}'
+      name: 'hello-helm-{{timestamp}}'
       ui-pipeline: true
       configuration:
         content:
@@ -73,17 +67,7 @@ services:
 form:
   pipeline:
     parameters:
-      app-name: >
-        $env.appName ?
-          '{{appName}}' : '{{services.repo.parameters.repo_name}}'
-      prod-cluster-namespace: >
-        $env.prodClusterNamespace ?
-          '{{prodClusterNamespace}}' : 'prod'
-      registry-region: '{{registryRegion}}'
-      registry-namespace: '{{registryNamespace}}'
-      api-key: '{{apiKey}}'
-      prod-region: '{{prodRegion}}'
-      prod-resource-group: '{{prodResourceGroup}}'
-      prod-cluster-name: '{{prodClusterName}}'
+      app-name: '{{services.repo.parameters.repo_name}}'
+      prod-cluster-namespace: prod
     schema:
       $ref: deploy.json


### PR DESCRIPTION
This reverts commit df7f2879c346003275c2d7683c60089da7b01301.
https://github.com/open-toolchain/simple-helm-toolchain/pull/51

because toolchain instance created through browser has a pipeline build that fails with:
```
Checking registry namespace: ${REGISTRY_NAMESPACE}
Registry namespace ${REGISTRY_NAMESPACE} not found, creating it.
FAILED
The requested namespace is not valid.
Choose a valid namespace value. Namespaces must be between 4 and 30 characters long, and contain lowercase letters, numbers, hyphens, and underscores only. Namespaces must start and end with a letter or number.
```

that is, the registry namespace chosen in the browser is not available to the build.