### PR TITLE
curated tekton helm toolchain template does not allow extra helm arguments $HELM_UPGRADE_EXTRA_ARGS

### DIFF
--- a/.pipeline/listener.yaml
+++ b/.pipeline/listener.yaml
@@ -41,14 +41,17 @@ spec:
         path to the folder containing the helm chart content (at least Chart.yaml).
         If not specified, it will default to first folder in /chart
       default: ""
-    - name: pipeline-debug
-      default: "0"
     - name: cluster-name
       description: the name of the cluster to target
     - name: dev-region
     - name: dev-resource-group
     - name: dev-cluster-namespace
       description: namespace dev
+    - name: helm-upgrade-extra-args
+      description: complementary argument for the helm upgrade command
+      default: ""
+    - name: pipeline-debug
+      default: "0"
   resourcetemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
@@ -105,6 +108,8 @@ spec:
             value: $(params.cluster-name)
           - name: dev-cluster-namespace
             value: $(params.dev-cluster-namespace)
+          - name: helm-upgrade-extra-args
+            value: $(params.helm-upgrade-extra-args)
           - name: pipeline-debug
             value: $(params.pipeline-debug)
         workspaces:

--- a/.pipeline/listener.yaml
+++ b/.pipeline/listener.yaml
@@ -48,7 +48,7 @@ spec:
     - name: dev-cluster-namespace
       description: namespace dev
     - name: helm-upgrade-extra-args
-      description: complementary argument for the helm upgrade command
+      description: complementary argument for the helm upgrade command. Can be used to specify an additional values file
       default: ""
     - name: pipeline-debug
       default: "0"

--- a/.pipeline/pipeline.yaml
+++ b/.pipeline/pipeline.yaml
@@ -48,6 +48,9 @@ spec:
       description: the name of the cluster to target
     - name: dev-cluster-namespace
       description: the namespace
+    - name: helm-upgrade-extra-args
+      description: complementary argument for the helm upgrade command
+      default: ""
     - name: pipeline-debug
       default: "0"
   workspaces:
@@ -272,6 +275,7 @@ spec:
           value: |
             export CLUSTER_NAMESPACE="$(params.dev-cluster-namespace)"
             export CHART_PATH="$(params.helm-chart-path)"
+            export HELM_UPGRADE_EXTRA_ARGS="$(params.helm-upgrade-extra-args)"
             # pipeline build number is the doi build record id (if any)
             export SOURCE_BUILD_NUMBER=$BUILD_NUMBER
             echo "SOURCE_BUILD_NUMBER=$BUILD_NUMBER" >> build.properties

--- a/.south-pipeline/listener.yaml
+++ b/.south-pipeline/listener.yaml
@@ -41,14 +41,17 @@ spec:
         path to the folder containing the helm chart content (at least Chart.yaml).
         If not specified, it will default to first folder in /chart
       default: ""
-    - name: pipeline-debug
-      default: "0"
     - name: cluster-name
       description: the name of the cluster to target
     - name: dev-region
     - name: dev-resource-group
     - name: dev-cluster-namespace
       description: namespace dev
+    - name: helm-upgrade-extra-args
+      description: complementary argument for the helm upgrade command
+      default: ""
+    - name: pipeline-debug
+      default: "0"
     - name: pr-url
       description: PR url
     - name: apikey
@@ -115,6 +118,8 @@ spec:
             value: $(params.cluster-name)
           - name: dev-cluster-namespace
             value: $(params.dev-cluster-namespace)
+          - name: helm-upgrade-extra-args
+            value: $(params.helm-upgrade-extra-args)
           - name: pipeline-debug
             value: $(params.pipeline-debug)
           - name: apikey

--- a/.south-pipeline/listener.yaml
+++ b/.south-pipeline/listener.yaml
@@ -48,7 +48,7 @@ spec:
     - name: dev-cluster-namespace
       description: namespace dev
     - name: helm-upgrade-extra-args
-      description: complementary argument for the helm upgrade command
+      description: complementary argument for the helm upgrade command. Can be used to specify an additional values file
       default: ""
     - name: pipeline-debug
       default: "0"

--- a/.south-pipeline/pipeline.yaml
+++ b/.south-pipeline/pipeline.yaml
@@ -48,6 +48,9 @@ spec:
       description: the name of the cluster to target
     - name: dev-cluster-namespace
       description: the namespace
+    - name: helm-upgrade-extra-args
+      description: complementary argument for the helm upgrade command
+      default: ""
     - name: pipeline-debug
       default: "0"
     - name: pr-url
@@ -374,6 +377,7 @@ spec:
           value: |
             export CLUSTER_NAMESPACE="$(params.dev-cluster-namespace)"
             export CHART_PATH="$(params.helm-chart-path)"
+            export HELM_UPGRADE_EXTRA_ARGS="$(params.helm-upgrade-extra-args)"
             # pipeline build number is the doi build record id (if any)
             export SOURCE_BUILD_NUMBER=$BUILD_NUMBER
             echo "SOURCE_BUILD_NUMBER=$BUILD_NUMBER" >> build.properties


### PR DESCRIPTION
curated tekton helm toolchain template does not allow extra helm arguments $HELM_UPGRADE_EXTRA_ARGS
https://github.ibm.com/org-ids/roadmap/issues/15277

This can be used in a CD Trigger PipelineRun with environment property `helm-upgrade-extra-args` with value `--set-string replicaCount=1` for instance.
This can be used also to specifiy a specific complementary values file (using `-f` option of helm) that can provide specific values for target deployment environment 