### PR TITLE
Generate Tekton pipeline repo name based on toolchain name

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -42,10 +42,10 @@ services:
       repo_url: >
         $env.type === 'link' ? $env.app_repo :
           $env.sourceZipUrl ? '{{sourceZipUrl}}' :
-            'https://github.com/open-toolchain/hello-helm'       
+            'https://github.com/open-toolchain/hello-helm'
       source_repo_url: >
         $env.type === 'fork' || $env.type === 'clone' ? $env.app_repo :
-          $env.sourceZipUrl ? '{{sourceZipUrl}}' : 
+          $env.sourceZipUrl ? '{{sourceZipUrl}}' :
             'https://github.com/open-toolchain/hello-helm'
       type: $env.type || 'clone'
       has_issues: true
@@ -55,10 +55,10 @@ services:
     service_id: >
       $env.pipeline_type === 'tekton' ? $env.source_provider ? $env.source_provider : 'hostedgit' : ''
     parameters:
-      repo_name: "simple-helm-toolchain-{{timestamp}}"
+      repo_name: $env.toolchainName ? '{{toolchainName}}-pipeline' : "simple-helm-toolchain-{{timestamp}}"
       repo_url: >
         $env.repository
-      source_repo_url: "https://github.com/open-toolchain/simple-helm-toolchain" 
+      source_repo_url: "https://github.com/open-toolchain/simple-helm-toolchain"
       type: $env.type || 'clone'
       has_issues: false
       enable_traceability: false


### PR DESCRIPTION
This will allow us to match code repo with pipeline repo by name for test automation (e.g., for cleanup)