### PR TITLE
Add skip vuln scan feature

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -86,6 +86,9 @@ stages:
   - name: PIPELINE_IMAGE_URL
     value: ''
     type: text
+  - name: SKIP_VA_SCAN
+    value: "false"
+    type: text
   inputs:
   - type: job
     stage: BUILD
@@ -104,7 +107,6 @@ stages:
       # alternatively, you can source it from online script:
       #    source <(curl -sSL "${COMMONS_HOSTED_REGION}/scripts/check_dockerfile.sh")
       # ------------------
-
       # This script lints Dockerfile.
       source <(curl -sSL "${COMMONS_HOSTED_REGION}/scripts/check_dockerfile.sh")
   - name: Check registry
@@ -168,7 +170,15 @@ stages:
       #    source <(curl -sSL "${COMMONS_HOSTED_REGION}/scripts/check_vulnerabilities.sh")
       # ------------------
       # Check for vulnerabilities of built image using Vulnerability Advisor
-      source <(curl -sSL "${COMMONS_HOSTED_REGION}/scripts/check_vulnerabilities.sh")
+      if [ "${SKIP_VA_SCAN}" == "true" ]
+      then
+        yellow="\x1b[33m"
+        no_color="\x1b[0m"
+        echo -e "${yellow}WARNING:${no_color} Skipping vulnerability scan; any vulnerabilities in the build image will NOT be detected. Found SKIP_VA_SCAN=${SKIP_VA_SCAN}"
+      else
+        # Check for vulnerabilities of built image using Vulnerability Advisor
+        source <(curl -sSL "${COMMONS_HOSTED_REGION}/scripts/check_vulnerabilities.sh")
+      fi
 - name: DEPLOY
   inputs:
   - type: job


### PR DESCRIPTION
Adds a "SKIP_VA_SCAN" property to the template (for classic pipeline). This allows the pipeline to skip the VA scan job and will be used by our e2e to ensure slow/failed VA doesnt fail our e2e tests and block deployments. But the VA scan will still be enabled by default